### PR TITLE
PR: Se ha creado el DAO de Etiquetas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,13 +18,16 @@ El formato está basado en [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 #### `25/09/2024`
 
+- Se ha creado el Objeto de Acceso a Datos (`TagDAO`) para la entidad `Tag`.
+
+
 - Se ha implementado el endpoint de Imágenes que nos permite recuperar todas las imágenes almacenadas en la base de datos.
   - Se ha creado el repositorio `ImageRepository` para recuperar la información de la Base de Datos mediante el DAO `ImageDao`.
   - Se ha creado el servicio `ImageService` para recuperar la información mediante el repositorio `ImageRepository`.
   - Se ha creado el controlador `ImageRestController` para recuperar la información mediante el servicio `ImageService`.
 
 
-- Se ha creado el Objeto de Acceso a Datos (`DAO`) para la entidad `Image`.
+- Se ha creado el Objeto de Acceso a Datos (`ImageDAO`) para la entidad `Image`.
 
 
 - Se han creado los siguientes Objetos de Transferencia de Datos (`DTO`) para las entidades `Image`, `Tag` y `Category`:

--- a/src/main/java/com/aipixel/api/component/tag/repository/TagDao.java
+++ b/src/main/java/com/aipixel/api/component/tag/repository/TagDao.java
@@ -1,0 +1,18 @@
+package com.aipixel.api.component.tag.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Component;
+
+
+
+/**
+ * DAO que proporciona operaciones de persistencia relacionadas con las etiquetas.
+ *
+ * @See JpaRepository
+ * @See TagModel
+ * @See Long
+ */
+@Component
+public interface TagDao extends JpaRepository<TagModel, Long> {
+
+}


### PR DESCRIPTION
- Se ha creado el DAO TagDao con la ayuda de JpaRepository para habilitar las operaciones básicas contra la Base de Datos relacionadas con la información almacenada de las etiquetas.

- Se ha añadido el cambio al fichero CHANGELOG.md.

#4