### PR TITLE
PR: Se ha creado el DAO de Categorías

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ El formato está basado en [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 #### `25/09/2024`
 
+- Se ha creado el Objeto de Acceso a Datos (`CategoryDAO`) para la entidad `Category`.
+
+
 - Se ha creado el Objeto de Acceso a Datos (`TagDAO`) para la entidad `Tag`.
 
 

--- a/src/main/java/com/aipixel/api/component/category/repository/CategoryDao.java
+++ b/src/main/java/com/aipixel/api/component/category/repository/CategoryDao.java
@@ -1,0 +1,18 @@
+package com.aipixel.api.component.category.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Component;
+
+
+
+/**
+ * DAO que proporciona operaciones de persistencia relacionadas con las categorías.
+ *
+ * @See JpaRepository
+ * @See CategoryModel
+ * @See Long
+ */
+@Component
+public interface CategoryDao extends JpaRepository<CategoryModel, Long> {
+
+}


### PR DESCRIPTION
- Se ha creado el DAO CategoryDao con la ayuda de JpaRepository para habilitar las operaciones básicas contra la Base de Datos relacionadas con la información almacenada de las categorías.

- Se ha añadido el cambio al fichero CHANGELOG.md.

#5